### PR TITLE
Feature/pages

### DIFF
--- a/src/app/(student)/home/page.tsx
+++ b/src/app/(student)/home/page.tsx
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <div>ホーム画面</div>;
+}

--- a/src/app/(student)/layout.tsx
+++ b/src/app/(student)/layout.tsx
@@ -1,0 +1,9 @@
+import AppLayout from "@/component/AppLayout";
+
+export default function StudentLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <AppLayout>{children}</AppLayout>;
+}

--- a/src/app/(student)/profile/page.tsx
+++ b/src/app/(student)/profile/page.tsx
@@ -1,0 +1,3 @@
+export default function ProfilePage() {
+  return <div>プロフィール</div>;
+}

--- a/src/app/(student)/quest/page.tsx
+++ b/src/app/(student)/quest/page.tsx
@@ -1,0 +1,3 @@
+export default function QuestionPage() {
+  return <div>クエスト一覧</div>;
+}

--- a/src/app/(student)/question/page.tsx
+++ b/src/app/(student)/question/page.tsx
@@ -1,0 +1,3 @@
+export default function QuestionPage() {
+  return <div>探究ノート</div>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import AppLayout from "@/component/AppLayout";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,7 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        <AppLayout>{children}</AppLayout>
+        {children}
       </body>
     </html>
   );

--- a/src/component/AppLayout/index.tsx
+++ b/src/component/AppLayout/index.tsx
@@ -27,7 +27,6 @@ const AppLayout = ({ children }: AppLayoutProps) => {
     localStorage.setItem("sidebarOpen", JSON.stringify(newState));
   };
 
-  // 初期化が完了するまでは、デフォルト状態で表示（フラッシュを防ぐ）
   if (isSidebarOpen === null) {
     return (
       <div style={{ display: "flex", minHeight: "100vh" }}>

--- a/src/component/Sidebar/index.tsx
+++ b/src/component/Sidebar/index.tsx
@@ -27,12 +27,12 @@ const Sidebar = ({ isOpen, userIconUrl, onToggle }: SidebarProps) => {
     {
       name: "ホーム",
       icon: Home,
-      href: "/",
+      href: "/home",
     },
     {
       name: "探究ノート",
       icon: BookOpen,
-      href: "/notes",
+      href: "/question",
     },
     {
       name: "クエスト",


### PR DESCRIPTION
- `(student)`ディレクトリ直下に`/home`, `/profile`, `/quest`, `/question`を作成
- サイドバーナビゲーションのurlを対応
- サイドバーをrootの`layout.tsx`から`(student)`の`layout.tsx`に移動

### ディレクトリ構成（加えた部分のみ）
<img width="258" height="184" alt="image" src="https://github.com/user-attachments/assets/01c73ea1-0d86-4d62-a477-f18dd959e353" />
